### PR TITLE
Fix AC_chnGESWICH mistake

### DIFF
--- a/Kamek/include/actors.h
+++ b/Kamek/include/actors.h
@@ -72,7 +72,7 @@ enum Actors {
 	AC_4SWICHAND = 65,
 	AC_4SWICHOR = 66,
 	AC_RANDSWICH = 67,
-	AC_chnGESWICH = 68,
+	AC_CHNGESWICH = 68,
 	AC_IFSWICH = 69,
 	AC_RNSWICH = 70,
 	EN_BKBLOCK = 71,
@@ -830,3 +830,4 @@ Actors translateActorID(Actors id);
 Actors adjustID(Actors id);
 
 #endif
+


### PR DESCRIPTION
The `actors.h` file was edited in 1.30 to replace `AC_CHNGESWICH` with `AC_chnGESWICH` (now partially lowercase). This is incorrect and frankly completely unacceptable. This mistake has propagated to my own projects, and probably many others', with potentially even more alarming downstream effects to come. If not amended, this egregious spelling error could infect tens if not millions of other projects. Please merge this pull request before it's too late!!!