### PR TITLE
Fix strange (and likely unintended) collision behavior with the Fuzzy Bear boss

### DIFF
--- a/Kamek/src/bossFuzzyBear.cpp
+++ b/Kamek/src/bossFuzzyBear.cpp
@@ -95,20 +95,8 @@ bool daFuzzyBear_c::collisionCat1_Fireball_E_Explosion(ActivePhysics *apThis, Ac
 	return true;
 }
 bool daFuzzyBear_c::collisionCat7_GroundPound(ActivePhysics *apThis, ActivePhysics *apOther) { 
-	apOther->someFlagByte |= 2;
-
-	dActor_c *block = apOther->owner;
-	dEn_c *mario = (dEn_c*)block;
-
-	mario->speed.y = -mario->speed.y;
-	mario->pos.y += mario->speed.y;
-
-	if (mario->direction == 0) { mario->speed.x = 4.0; }
-	else					  { mario->speed.x = -4.0; }
-	
-	mario->doSpriteMovement();
-	mario->doSpriteMovement();
-	return true;
+	this->counter_504[apOther->owner->which_player] = 0;
+	return this->collisionCat9_RollingObject(apThis, apOther);
 }
 bool daFuzzyBear_c::collisionCat7_GroundPoundYoshi(ActivePhysics *apThis, ActivePhysics *apOther) { 
 	this->counter_504[apOther->owner->which_player] = 0;


### PR DESCRIPTION
This boss has ground pound collision behavior that is completely different than the one used for Yoshi, with the cost being that it... doesn't really work properly at all. This issue can be replicated in likely every single mod that didn't modify this file, and it's almost a little surprising that nobody's noticed this.

If you're too lazy to test the code out yourself, I've made a fun little video demonstrating what happens and what the fix looks like:
https://youtu.be/qrK5n1ScwHw

(All of this is under the assumption that Mario teleporting all over the place when trying to attack the boss isn't intended, which _hopefully_ isn't that much of a stretch)