### PR TITLE
Remove the ability to pick up the Fake Star Coin (why was this a thing before)

### DIFF
--- a/Kamek/src/bossFuzzyBear.cpp
+++ b/Kamek/src/bossFuzzyBear.cpp
@@ -95,20 +95,8 @@ bool daFuzzyBear_c::collisionCat1_Fireball_E_Explosion(ActivePhysics *apThis, Ac
 	return true;
 }
 bool daFuzzyBear_c::collisionCat7_GroundPound(ActivePhysics *apThis, ActivePhysics *apOther) { 
-	apOther->someFlagByte |= 2;
-
-	dActor_c *block = apOther->owner;
-	dEn_c *mario = (dEn_c*)block;
-
-	mario->speed.y = -mario->speed.y;
-	mario->pos.y += mario->speed.y;
-
-	if (mario->direction == 0) { mario->speed.x = 4.0; }
-	else					  { mario->speed.x = -4.0; }
-	
-	mario->doSpriteMovement();
-	mario->doSpriteMovement();
-	return true;
+	this->counter_504[apOther->owner->which_player] = 0;
+	return this->collisionCat9_RollingObject(apThis, apOther);
 }
 bool daFuzzyBear_c::collisionCat7_GroundPoundYoshi(ActivePhysics *apThis, ActivePhysics *apOther) { 
 	this->counter_504[apOther->owner->which_player] = 0;

--- a/Kamek/src/bossFuzzyBear.cpp
+++ b/Kamek/src/bossFuzzyBear.cpp
@@ -95,8 +95,20 @@ bool daFuzzyBear_c::collisionCat1_Fireball_E_Explosion(ActivePhysics *apThis, Ac
 	return true;
 }
 bool daFuzzyBear_c::collisionCat7_GroundPound(ActivePhysics *apThis, ActivePhysics *apOther) { 
-	this->counter_504[apOther->owner->which_player] = 0;
-	return this->collisionCat9_RollingObject(apThis, apOther);
+	apOther->someFlagByte |= 2;
+
+	dActor_c *block = apOther->owner;
+	dEn_c *mario = (dEn_c*)block;
+
+	mario->speed.y = -mario->speed.y;
+	mario->pos.y += mario->speed.y;
+
+	if (mario->direction == 0) { mario->speed.x = 4.0; }
+	else					  { mario->speed.x = -4.0; }
+	
+	mario->doSpriteMovement();
+	mario->doSpriteMovement();
+	return true;
 }
 bool daFuzzyBear_c::collisionCat7_GroundPoundYoshi(ActivePhysics *apThis, ActivePhysics *apOther) { 
 	this->counter_504[apOther->owner->which_player] = 0;

--- a/Kamek/src/fakeStarCoin.cpp
+++ b/Kamek/src/fakeStarCoin.cpp
@@ -131,7 +131,7 @@ int daFakeStarCoin::onCreate() {
 	HitMeBaby.category1 = 0x5;
 	HitMeBaby.category2 = 0x0;
 	HitMeBaby.bitfield1 = 0x4F;
-	HitMeBaby.bitfield2 = 0xFFFFFFFF;
+	HitMeBaby.bitfield2 = 0xFFBAFFFE;
 	HitMeBaby.unkShort1C = 0;
 	HitMeBaby.callback = &dEn_c::collisionCallback;
 


### PR DESCRIPTION
copied from the most recent commit in this pull request, in case github somehow refuses to show it:

"In NewerSMBW, you can pick up fake star coins similar to how one picks up a player or POW block. However, not only is this obviously unintended, but the feature doesn't even work (you just pick up/throw air)! How disappointing...

All jokes aside, this has probably leaked its way into every major mod I can think of that uses this sprite, so it'd probably be good to fix it before we taint the future generation."