### PR TITLE
Fix compiling without fasthack

### DIFF
--- a/Kamek/include/common.h
+++ b/Kamek/include/common.h
@@ -127,7 +127,7 @@ char *RetrieveFileFromArcAlt(void *table, char *name, char *path);*/
 extern void *ArchiveHeap; // PAL 0x8042A72C, NTSC 0x8042A44C
 
 namespace nw4r { namespace math { float FrSqrt(float); }}
-float sqrtf(float x) {
+inline float sqrtf(float x) {
     return (x <= 0) ? 0.0f : x * nw4r::math::FrSqrt(x);
 }
 

--- a/Kamek/src/apDebug.cpp
+++ b/Kamek/src/apDebug.cpp
@@ -17,7 +17,7 @@ class APDebugDrawer : public m3d::proc_c {
 
 
 static APDebugDrawer defaultInstance;
-static bool enableDebugMode = false;
+extern bool enableDebugMode = false;
 
 int APDebugDraw() {
 	if (enableDebugMode)

--- a/Kamek/src/bonusRoom.cpp
+++ b/Kamek/src/bonusRoom.cpp
@@ -3,6 +3,7 @@
 #include <g3dhax.h>
 #include <sfx.h>
 #include <stage.h>
+#include <playerAnim.h>
 
 extern "C" void *MakeMarioEnterDemoMode();
 extern "C" void *MakeMarioExitDemoMode();

--- a/Kamek/src/bossBalboaWrench.cpp
+++ b/Kamek/src/bossBalboaWrench.cpp
@@ -5,6 +5,8 @@
 #include <stage.h>
 #include "boss.h"
 
+extern "C" void dAcPy_vf3F8(void* player, dEn_c* monster, int t);
+
 class daBalboa_c : public daBoss {
 	int onCreate();
 	int onDelete();

--- a/Kamek/src/bossCaptainBowser.cpp
+++ b/Kamek/src/bossCaptainBowser.cpp
@@ -3,6 +3,7 @@
 #include <g3dhax.h>
 #include <sfx.h>
 #include <stage.h>
+#include <playerAnim.h>
 #include "boss.h"
 
 extern "C" void *StageScreen;

--- a/Kamek/src/bossSamurshai.cpp
+++ b/Kamek/src/bossSamurshai.cpp
@@ -6,6 +6,7 @@
 
 extern "C" void *SoundRelatedClass;
 extern "C" void *MapSoundPlayer(void *SoundRelatedClass, int soundID, int unk);
+extern "C" void dAcPy_vf3F8(void* player, dEn_c* monster, int t);
 
 
 const char* SSarcNameList [] = {

--- a/Kamek/src/koopatlas/core.cpp
+++ b/Kamek/src/koopatlas/core.cpp
@@ -4,6 +4,7 @@
 #include "music.h"
 
 extern "C" void LoadMapScene();
+extern u8 MaybeFinishingLevel[2];
 
 dScKoopatlas_c *dScKoopatlas_c::instance = 0;
 

--- a/Kamek/src/koopatlas/mapmusic.cpp
+++ b/Kamek/src/koopatlas/mapmusic.cpp
@@ -1,4 +1,5 @@
 #include <game.h>
+#include <sfx.h>
 #include "koopatlas/mapmusic.h"
 #include "music.h"
 

--- a/Kamek/src/koopatlas/pathmanager.cpp
+++ b/Kamek/src/koopatlas/pathmanager.cpp
@@ -3,6 +3,7 @@
 #include "koopatlas/hud.h"
 #include "koopatlas/player.h"
 #include "koopatlas/map.h"
+#include "koopatlas/camera.h"
 #include <sfx.h>
 #include <stage.h>
 

--- a/Kamek/src/levelspecial.cpp
+++ b/Kamek/src/levelspecial.cpp
@@ -52,7 +52,6 @@ extern char isLockPlayerRotation;
 
 #define time *(u32*)((GameTimer) + 0x4)
 
-
 static const float GlobalSizeFloatModifications [] = {1, 0.25, 0.5, 0.75, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5, 6, 7, 8, 10 };
 static const float GlobalRiderFloatModifications [] = {1, 0.6, 0.7, 0.9, 1, 1, 1, 1.1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 5};
 static const float BGScaleChoices[] = {0.1f, 0.15f, 0.25f, 0.375f, 0.5f, 0.625f, 0.75f, 0.9f, 1.0f, 1.125f, 1.25f, 1.5f, 1.75f, 2.0f, 2.25f, 2.5f};
@@ -302,3 +301,5 @@ void LevelSpecial_Update(LevelSpecial *self) {
 	
 	self->lastEvState = newEvState;
 }
+
+#undef time

--- a/Kamek/src/msgbox.cpp
+++ b/Kamek/src/msgbox.cpp
@@ -1,5 +1,6 @@
 #include <common.h>
 #include <game.h>
+#include <sfx.h>
 #include "msgbox.h"
 
 // Replaces: EN_LIFT_ROTATION_HALF (Sprite 107; Profile ID 481 @ 80AF96F8)

--- a/Kamek/src/nsmbwVer.cpp
+++ b/Kamek/src/nsmbwVer.cpp
@@ -1,3 +1,4 @@
+#include <common.h>
 #include "nsmbwVer.h"
 
 NSMBWVer getNsmbwVer()

--- a/Kamek/src/shyguyGiants.cpp
+++ b/Kamek/src/shyguyGiants.cpp
@@ -3,6 +3,7 @@
 #include <g3dhax.h>
 #include <sfx.h>
 
+extern void shyCollisionCallback(ActivePhysics *apThis, ActivePhysics *apOther);	
 
 const char* SGGarcNameList [] = {
 	"shyguy",


### PR DESCRIPTION
By default, `makeGame.py` enables the fast-hack feature, which combines all C++ code into a single file to be compiled. However, due to various undefined variables and other issues, the code is unable to be compiled with fast-hack off. Furthermore, when fast-hack is enabled, the term "time" cannot be used in any code after `levelSpecial.cpp`, as it is never undefined.

This PR fixes all of the issues that are "fixed" by fast-hack being enabled (as well at the "time" issue), so now Newer (and any specials that were broken) can now be successfully compiled both with and without it.